### PR TITLE
dev-dy: JWT 새로운 access token 발급 로직 구현

### DIFF
--- a/src/main/java/net/devgrr/interp/ia/api/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/devgrr/interp/ia/api/config/exception/GlobalExceptionHandler.java
@@ -1,8 +1,13 @@
 package net.devgrr.interp.ia.api.config.exception;
 
+import java.security.SignatureException;
 import java.util.stream.Collectors;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -57,5 +62,29 @@ public class GlobalExceptionHandler {
       return ResponseEntity.internalServerError()
           .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage()));
     }
+  }
+
+  @ExceptionHandler(SignatureException.class)
+  public ResponseEntity<ErrorResponse> handle(SignatureException e) {
+    return ResponseEntity.status(401)
+        .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
+  }
+
+  @ExceptionHandler(TokenExpiredException.class)
+  public ResponseEntity<ErrorResponse> handle(TokenExpiredException e) {
+    return ResponseEntity.status(401)
+        .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
+  }
+
+  @ExceptionHandler(JWTDecodeException.class)
+  public ResponseEntity<ErrorResponse> handle(JWTDecodeException e) {
+    return ResponseEntity.status(401)
+        .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
+  }
+
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handle(AccessDeniedException e) {
+    return ResponseEntity.status(401)
+        .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
   }
 }

--- a/src/main/java/net/devgrr/interp/ia/api/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/devgrr/interp/ia/api/config/exception/GlobalExceptionHandler.java
@@ -1,10 +1,7 @@
 package net.devgrr.interp.ia.api.config.exception;
 
-import java.security.SignatureException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import java.util.stream.Collectors;
-
-import com.auth0.jwt.exceptions.JWTDecodeException;
-import com.auth0.jwt.exceptions.TokenExpiredException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -64,8 +61,8 @@ public class GlobalExceptionHandler {
     }
   }
 
-  @ExceptionHandler(TokenExpiredException.class)
-  public ResponseEntity<ErrorResponse> handle(TokenExpiredException e) {
+  @ExceptionHandler(JWTVerificationException.class)
+  public ResponseEntity<ErrorResponse> handle(JWTVerificationException e) {
     return ResponseEntity.status(401)
         .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
   }

--- a/src/main/java/net/devgrr/interp/ia/api/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/net/devgrr/interp/ia/api/config/exception/GlobalExceptionHandler.java
@@ -50,7 +50,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(AuthenticationException.class)
   protected ResponseEntity<ErrorResponse> handle(AuthenticationException e) {
-    return ResponseEntity.badRequest().body(new ErrorResponse(ErrorCode.FORBIDDEN));
+    return ResponseEntity.status(403).body(new ErrorResponse(ErrorCode.FORBIDDEN, e.getMessage()));
   }
 
   @ExceptionHandler(ResponseStatusException.class)
@@ -64,20 +64,8 @@ public class GlobalExceptionHandler {
     }
   }
 
-  @ExceptionHandler(SignatureException.class)
-  public ResponseEntity<ErrorResponse> handle(SignatureException e) {
-    return ResponseEntity.status(401)
-        .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
-  }
-
   @ExceptionHandler(TokenExpiredException.class)
   public ResponseEntity<ErrorResponse> handle(TokenExpiredException e) {
-    return ResponseEntity.status(401)
-        .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
-  }
-
-  @ExceptionHandler(JWTDecodeException.class)
-  public ResponseEntity<ErrorResponse> handle(JWTDecodeException e) {
     return ResponseEntity.status(401)
         .body(new ErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage()));
   }

--- a/src/main/java/net/devgrr/interp/ia/api/config/security/SecurityConfig.java
+++ b/src/main/java/net/devgrr/interp/ia/api/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import net.devgrr.interp.ia.api.jwt.JwtService;
+import net.devgrr.interp.ia.api.jwt.exceptionHandler.JwtAuthenticationEntryPoint;
 import net.devgrr.interp.ia.api.jwt.filter.JwtAuthenticationProcessingFilter;
 import net.devgrr.interp.ia.api.login.LoginService;
 import net.devgrr.interp.ia.api.login.filter.JsonUsernamePasswordAuthenticationFilter;
@@ -38,6 +39,8 @@ public class SecurityConfig {
   private final JwtService jwtService;
   private final ApiLoggingFilter apiLoggingFilter;
 
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
   @Bean
   SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
     httpSecurity
@@ -61,7 +64,7 @@ public class SecurityConfig {
                         new AntPathRequestMatcher("/login"),
                         new AntPathRequestMatcher("/api/users/signup"),
                         new AntPathRequestMatcher("/error"))
-                    .permitAll()
+                        .permitAll()
                     .requestMatchers(new AntPathRequestMatcher("/admin"))
                     .hasRole("ADMIN")
                     .anyRequest()
@@ -69,7 +72,11 @@ public class SecurityConfig {
         .addFilterBefore(apiLoggingFilter, LogoutFilter.class)
         .addFilterBefore(jwtAuthenticationProcessingFilter(), LogoutFilter.class)
         .addFilterBefore(
-            jsonUsernamePasswordLoginFilter(), UsernamePasswordAuthenticationFilter.class);
+            jsonUsernamePasswordLoginFilter(), UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(
+            exceptionHandler -> {
+              exceptionHandler.authenticationEntryPoint(jwtAuthenticationEntryPoint);
+            });
 
     return httpSecurity.build();
   }

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/JwtController.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/JwtController.java
@@ -16,4 +16,11 @@ public class JwtController {
     @PostMapping("/refresh")
     @ResponseStatus(HttpStatus.OK)
     public void getNewAccessToken() {}
+
+    @Operation(description = "/admin 엔드포인트 테스트 컨트롤러")
+    @GetMapping("/admin")
+    @ResponseStatus(HttpStatus.OK)
+    public String getAdmin() {
+        return "admin";
+    }
 }

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/JwtController.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/JwtController.java
@@ -1,15 +1,11 @@
 package net.devgrr.interp.ia.api.jwt;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Validated
 @RequiredArgsConstructor

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/JwtController.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/JwtController.java
@@ -1,0 +1,23 @@
+package net.devgrr.interp.ia.api.jwt;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RequiredArgsConstructor
+@Tag(name = "JwtController", description = "토큰 API")
+@RestController
+public class JwtController {
+    @Operation(description = "refreshToken 으로 새로운 accessToken을 받는다.")
+    @PostMapping("/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    public void getNewAccessToken() {}
+}

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/JwtService.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/JwtService.java
@@ -9,11 +9,14 @@ import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import net.devgrr.interp.ia.api.config.exception.BaseException;
+import net.devgrr.interp.ia.api.config.exception.ErrorCode;
 import net.devgrr.interp.ia.api.config.mapStruct.MemberMapper;
 import net.devgrr.interp.ia.api.member.MemberRepository;
 import net.devgrr.interp.ia.api.member.entity.Member;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -128,12 +131,12 @@ public class JwtService {
     response.setHeader(refreshHeader, refreshToken);
   }
 
-  public boolean isTokenValid(String token) {
+  public boolean isTokenValid(HttpServletRequest request, String token) {
     try {
       JWT.require(Algorithm.HMAC512(secret)).build().verify(token);
       return true;
     } catch (Exception e) {
-      System.out.println("[ERROR] Invalid Token : " + e.getMessage());
+      request.setAttribute("exception", e);
       return false;
     }
   }

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/exceptionHandler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/exceptionHandler/JwtAuthenticationEntryPoint.java
@@ -2,10 +2,13 @@ package net.devgrr.interp.ia.api.jwt.exceptionHandler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
@@ -25,6 +28,9 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     if (exception != null) {
       handlerExceptionResolver.resolveException(
           request, response, null, (Exception) request.getAttribute("exception"));
+    } else {
+      handlerExceptionResolver.resolveException(
+          request, response, null, new AuthenticationException("권한이 없습니다.", authException){});
     }
   }
 }

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/exceptionHandler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/exceptionHandler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package net.devgrr.interp.ia.api.jwt.exceptionHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+  private final HandlerExceptionResolver handlerExceptionResolver;
+
+  public JwtAuthenticationEntryPoint(HandlerExceptionResolver handlerExceptionResolver) {
+    this.handlerExceptionResolver = handlerExceptionResolver;
+  }
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException) {
+    Exception exception = (Exception) request.getAttribute("exception");
+
+    if (exception != null) {
+      handlerExceptionResolver.resolveException(
+          request, response, null, (Exception) request.getAttribute("exception"));
+    }
+  }
+}

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/exceptionHandler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/exceptionHandler/JwtAuthenticationEntryPoint.java
@@ -2,13 +2,10 @@ package net.devgrr.interp.ia.api.jwt.exceptionHandler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
-
-import java.io.IOException;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {

--- a/src/main/java/net/devgrr/interp/ia/api/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/net/devgrr/interp/ia/api/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -67,6 +67,9 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     }
 
     // Access Token 재발급
+    // securityContext 에 refreshToken 가지고 있는 Member 정보 저장
+    // /refresh => User 이상 권한 필요함
+    saveAuthentication(member);
     jwtService.sendAccessToken(response, jwtService.createAccessToken(member.getEmail()));
   }
 

--- a/src/main/java/net/devgrr/interp/ia/api/login/LoginController.java
+++ b/src/main/java/net/devgrr/interp/ia/api/login/LoginController.java
@@ -7,10 +7,7 @@ import net.devgrr.interp.ia.api.member.dto.LoginRequest;
 import net.devgrr.interp.ia.api.member.dto.MemberValidationGroup;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Validated
 @RequiredArgsConstructor

--- a/src/main/java/net/devgrr/interp/ia/api/login/filter/JsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/net/devgrr/interp/ia/api/login/filter/JsonUsernamePasswordAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JsonUsernamePasswordAuthenticationFilter
   @Override
   public Authentication attemptAuthentication(
       HttpServletRequest request, HttpServletResponse response)
-      throws AuthenticationException, IOException, ServletException {
+      throws AuthenticationException, IOException {
 
     if (!request.getContentType().equals(CONTENT_TYPE)) {
       throw new AuthenticationServiceException(

--- a/src/test/java/net/devgrr/interp/ia/api/jwt/JwtServiceTest.java
+++ b/src/test/java/net/devgrr/interp/ia/api/jwt/JwtServiceTest.java
@@ -1,0 +1,261 @@
+package net.devgrr.interp.ia.api.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import net.devgrr.interp.ia.api.member.dto.LoginRequest;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class JwtServiceTest {
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper mapper;
+
+  @Autowired private JwtService jwtService;
+
+  private final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+  @Test
+  @DisplayName("로그인 이후 필터를 통한 유효 토큰 발급 테스트")
+  public void GetAdminTokensTest() throws Exception {
+    // when
+    LoginRequest loginRequest = new LoginRequest("admin@admin.com", "admin");
+    String loginJson = mapper.writeValueAsString(loginRequest);
+
+    // given
+    MvcResult mvcResult =
+        mockMvc
+            .perform(
+                MockMvcRequestBuilders.post("/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(loginJson))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn();
+
+    String accessToken = mvcResult.getResponse().getHeader("authorization");
+    String refreshToken = mvcResult.getResponse().getHeader("authorization-refresh");
+
+    // then
+    Assertions.assertTrue(jwtService.isTokenValid(request, accessToken));
+    Assertions.assertTrue(jwtService.isTokenValid(request, refreshToken));
+  }
+
+  @Nested
+  @DisplayName("권한 검증 테스트")
+  class PermissionVerificationTest {
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessTest {
+      private String adminAccessToken;
+
+      @BeforeEach
+      void setAdminAccessToken() throws Exception {
+        LoginRequest loginRequest = new LoginRequest("admin@admin.com", "admin");
+        String loginJson = mapper.writeValueAsString(loginRequest);
+
+        MvcResult mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders.post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginJson))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        adminAccessToken = "Bearer " + mvcResult.getResponse().getHeader("authorization");
+      }
+
+      @Test
+      @DisplayName("admin 권한으로 /admin endpoint 접근")
+      public void accessAdminEndpointTest() throws Exception {
+        MvcResult mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders.get("/admin")
+                        .header("Authorization", adminAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        Assertions.assertEquals(200, mvcResult.getResponse().getStatus());
+        Assertions.assertEquals("admin", mvcResult.getResponse().getContentAsString());
+      }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailTest {
+      private String userAccessToken;
+
+      @BeforeEach
+      void setUserAccessToken() throws Exception {
+        LoginRequest loginRequest = new LoginRequest("user1@naver.com", "password");
+        String loginJson = mapper.writeValueAsString(loginRequest);
+
+        MvcResult mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders.post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginJson))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        userAccessToken = "Bearer " + mvcResult.getResponse().getHeader("authorization");
+      }
+
+      @Test
+      @DisplayName("user 권한으로 /admin endpoint 접근")
+      public void accessUserEndpointTest() throws Exception {
+        MvcResult result =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders.get("/admin")
+                        .header("Authorization", userAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isForbidden())
+                .andReturn();
+
+        Assertions.assertEquals(403, result.getResponse().getStatus());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("토큰 재발급 테스트")
+  class TokenReissueTest {
+    @Nested
+    @DisplayName("잘못된 토큰으로 접근 시 401 반환 테스트")
+    class WrongTokenTest {
+      @Test
+      @DisplayName("만료된 토큰 테스트")
+      public void expiredTokenTest() throws Exception {
+        String expiredToken =
+            "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImV4cCI6MTc0Mjk1NjM5NSwidXNlcm5hbWUiOiJhZG1pbkBhZG1pbi5jb20ifQ.wNDaiRdgp-862cLkctDsYD9a_FSTZpdhor73F7hhj7IXf6HGFHSgcQNOv2cfW81WzG6pQ9fe2fVP_2rAEuATcQ";
+
+        MvcResult mvcResult =
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders.get("/api/users")
+                        .header("Authorization", expiredToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                .andReturn();
+
+        Assertions.assertEquals(401, mvcResult.getResponse().getStatus());
+      }
+      @Test
+      @DisplayName("시그니처가 맞지 않는 토큰 테스트")
+      public void invalidTokenTest() throws Exception {
+        String expiredToken =
+                "Bearer eyJ0eXAiOiJKV1QiLCaaaaaaaIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImV4cCI6MTc0Mjk1NjM5NSwidXNlcm5hbWUiOiJhZG1pbkBhZG1pbi5jb20ifQ.wNDaiRdgp-862cLkctDsYD9a_FSTZpdhor73F7hhj7IXf6HGFHSgcQNOv2cfW81WzG6pQ9fe2fVP_2rAEuATcQ";
+
+        MvcResult mvcResult =
+                mockMvc
+                        .perform(
+                                MockMvcRequestBuilders.get("/api/users")
+                                        .header("Authorization", expiredToken)
+                                        .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                        .andReturn();
+
+        Assertions.assertEquals(401, mvcResult.getResponse().getStatus());
+      }
+    }
+    @Nested
+    @DisplayName("/refresh endpoint 로 accessToken 재발급 테스트")
+    class RefreshTokenTest {
+      @Nested
+      @DisplayName("성공 케이스")
+      class SuccessTest {
+        private String refreshToken;
+
+        @BeforeEach
+        public void setUserAccessToken() throws Exception {
+          LoginRequest loginRequest = new LoginRequest("admin@admin.com", "admin");
+          String loginJson = mapper.writeValueAsString(loginRequest);
+
+          MvcResult mvcResult =
+                  mockMvc
+                          .perform(
+                                  MockMvcRequestBuilders.post("/login")
+                                          .contentType(MediaType.APPLICATION_JSON)
+                                          .content(loginJson))
+                          .andExpect(MockMvcResultMatchers.status().isOk())
+                          .andReturn();
+          refreshToken = "Bearer " + mvcResult.getResponse().getHeader("authorization-refresh");
+        }
+        @Test
+        public void getNewAccessToken() throws Exception {
+          MvcResult mvcResult =
+                  mockMvc
+                          .perform(
+                                  MockMvcRequestBuilders.post("/refresh")
+                                          .header("Authorization-refresh", refreshToken)
+                                          .contentType(MediaType.APPLICATION_JSON))
+                          .andExpect(MockMvcResultMatchers.status().isOk())
+                          .andReturn();
+
+          Assertions.assertEquals(200, mvcResult.getResponse().getStatus());
+
+          String newAccessToken = mvcResult.getResponse().getHeader("Authorization");
+          Assertions.assertTrue(jwtService.isTokenValid(request, newAccessToken));
+        }
+      }
+      @Nested
+      @DisplayName("실패 케이스")
+      class FailTest {
+        @Test
+        @DisplayName("만료된 refreshToken 으로 재발급 요청 테스트")
+        public void expiredRefreshTokenTest() throws Exception {
+          String expiredToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJSZWZyZXNoVG9rZW4iLCJleHAiOjE3NDI5NTc1OTV9.53r9pzNj9tjfuVhh0qre6Tt0Bsc6NUFhwdzKlk_1vsNStnMgrBCZCxXwJuln2PgVKFfOKrEop--7y95Le1CEnw";
+          MvcResult mvcResult =
+                  mockMvc
+                          .perform(
+                                  MockMvcRequestBuilders.post("/refresh")
+                                          .header("Authorization-refresh", expiredToken)
+                                          .contentType(MediaType.APPLICATION_JSON))
+                          .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                          .andReturn();
+
+          Assertions.assertEquals(401, mvcResult.getResponse().getStatus());
+        }
+        @Test
+        @DisplayName("시그니처가 잘못된 refreshToken 으로 재발급 요청 테스트")
+        public void invalidRefreshTokenTest() throws Exception {
+          String invalidToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIaaaaaaaa.eyJzdWIiOiJSZWZyZXNoVG9rZW4iLCJleHAiOjE3NDI5NTc1OTV9.53r9pzNj9tjfuVhh0qre6Tt0Bsc6NUFhwdzKlk_1vsNStnMgrBCZCxXwJuln2PgVKFfOKrEop--7y95Le1CEnw";
+          MvcResult mvcResult =
+                  mockMvc
+                          .perform(
+                                  MockMvcRequestBuilders.post("/refresh")
+                                          .header("Authorization-refresh", invalidToken)
+                                          .contentType(MediaType.APPLICATION_JSON))
+                          .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                          .andReturn();
+
+          Assertions.assertEquals(401, mvcResult.getResponse().getStatus());
+        }
+        @Test
+        @DisplayName("빈 토큰으로 재발급 요청 테스트")
+        public void nullTokenTest() throws Exception {
+          MvcResult mvcResult =
+                  mockMvc
+                          .perform(
+                                  MockMvcRequestBuilders.post("/refresh")
+                                          .contentType(MediaType.APPLICATION_JSON))
+                          .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                          .andReturn();
+
+          Assertions.assertEquals(401, mvcResult.getResponse().getStatus());
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 개요
1. 잘못된 token 으로 접근 시 401 에러 반환 구현
2. 헤더에 Refresh token 입력 후 /refresh 엔드포인트로 접근 시 새로운 Access token 발급 로직 구현 
3. JWT 관련 테스트 코드 작성